### PR TITLE
Fix change audio device

### DIFF
--- a/Radiola/Player.swift
+++ b/Radiola/Player.swift
@@ -75,7 +75,7 @@ class Player: NSObject, AVPlayerItemMetadataOutputPushDelegate {
     var audioDeviceUID: String? {
         get { player.audioOutputDeviceUniqueID }
         set {
-            if player.audioOutputDeviceUniqueID == newValue {
+            if player.audioOutputDeviceUniqueID != newValue {
                 player.audioOutputDeviceUniqueID = newValue
                 settings.audioDevice = newValue
 


### PR DESCRIPTION
When changing audio device in the popup settings player use previous one.