### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/KeyboardShortcuts/RecorderCocoa.swift
+++ b/KeyboardShortcuts/RecorderCocoa.swift
@@ -300,7 +300,7 @@ extension KeyboardShortcuts {
 
 					self.focus()
 
-					// If the user has selected "Use Anyway" in the dialog (the second option), we'll continue setting the keyboard shorcut even though it's reserved by the system.
+					// If the user has selected "Use Anyway" in the dialog (the second option), we'll continue setting the keyboard shortcut even though it's reserved by the system.
 					guard modalResponse == .alertSecondButtonReturn else {
 						return nil
 					}

--- a/KeyboardShortcuts/Shortcut.swift
+++ b/KeyboardShortcuts/Shortcut.swift
@@ -27,7 +27,7 @@ extension KeyboardShortcuts {
 		public var modifiers: NSEvent.ModifierFlags { NSEvent.ModifierFlags(carbon: carbonModifiers) }
 
 		/**
-		Low-level represetation of the key.
+		Low-level representation of the key.
 
 		You most likely don't need this.
 		*/

--- a/KeyboardShortcuts/Utilities.swift
+++ b/KeyboardShortcuts/Utilities.swift
@@ -255,7 +255,7 @@ extension NSAlert {
 
 enum UnicodeSymbols {
 	/**
-	Represents the Function (Fn) key on the keybord.
+	Represents the Function (Fn) key on the keyboard.
 	*/
 	static let functionKey = "🌐\u{FE0E}"
 }

--- a/Radiola/AudioDevice.swift
+++ b/Radiola/AudioDevice.swift
@@ -89,7 +89,7 @@ struct AudioDevice {
         }
         UID = String(deviceUID)
 
-        // get deivce name
+        // get device name
         var deviceName = "" as CFString
         propertyAddress.mSelector = kAudioDevicePropertyDeviceNameCFString
         if AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, nil, &size, &deviceName) != noErr {
@@ -97,7 +97,7 @@ struct AudioDevice {
         }
         name = String(deviceName)
 
-        // get deivce manufacturer
+        // get device manufacturer
         var deviceManufacturer = "" as CFString
         propertyAddress.mSelector = kAudioDevicePropertyDeviceManufacturerCFString
         if AudioObjectGetPropertyData(deviceID, &propertyAddress, 0, nil, &size, &deviceManufacturer) != noErr {

--- a/Radiola/RadioBrowser/RadioBrowserStations.swift
+++ b/Radiola/RadioBrowser/RadioBrowserStations.swift
@@ -25,7 +25,7 @@ extension RadioBrowser {
         var url: String
 
         /// An automatically "resolved" stream URL. Things resolved are playlists (M3U/PLS/ASX...), HTTP redirects (Code 301/302).
-        /// This link is especially usefull if you use this API from a platform that is not able to do a resolve on its own
+        /// This link is especially useful if you use this API from a platform that is not able to do a resolve on its own
         /// (e.g. JavaScript in browser) or you just don't want to invest the time in decoding playlists yourself.
         var url_resolved: String
 

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -84,7 +84,7 @@
 &lt;li&gt;You can search and listen to stations from radio-browser.info.&lt;/li&gt;
 &lt;li&gt;Improved work with multimedia keys.&lt;/li&gt;
 &lt;li&gt;The current station and track are displayed in the system Now Playing info center.&lt;/li&gt;
-&lt;li&gt;Buffering is enabled, now the sound is not interrupted in case of short internet interupts.&lt;/li&gt;
+&lt;li&gt;Buffering is enabled, now the sound is not interrupted in case of short internet interrupts.&lt;/li&gt;
 &lt;/ul&gt;</description>
       <pubDate>Sat, 09 Mar 2024 17:53:39 +0000</pubDate>
       <enclosure url="https://github.com/SokoloffA/radiola/releases/download/v6.0/Radiola-6.0.dmg" sparkle:version="6.0" length="0" type="application/octet-stream"/>


### PR DESCRIPTION
Fix typos discovered by codespell -- https://github.com/codespell-project/codespell
% `codespell --ignore-words-list=pres,serie --skip="*.xcstrings" --write-changes`