### PR TITLE
ci: automated version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Use `directory: "/"` for workflow files stored in the default location of `.github/workflows`.
+    directory: "/"
+    schedule:
+      interval: "weekly"
+# <!--- NOTE: End of required stanzas. The following is all optional. -->
+      # By default, Dependabot checks for new versions on Monday at a
+      # random set time for the repository.
+      day: "sunday"
+    groups:
+      all-actions:
+        patterns:
+          # A wildcard that matches all dependencies in the package
+          # ecosystem. Note: using "*" may open a large pull request.
+          - "*"
+        update-types:
+          # Any packages where the highest resolvable version is minor
+          # or patch will be grouped together. Dependabot will create a
+          # separate pull request for any package that doesn't update to
+          # a minor or patch version.
+          - "minor"
+          - "patch"

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -39,7 +39,7 @@ jobs:
             echo ${GITHUB_REF_NAME} | grep -q "^v[0-9]\+\.[0-9]\+\.[0-9]\+$" || ( echo "Incorrect tag ${GITHUB_REF_NAME}" ; false ) \
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Build
         run: |
@@ -53,7 +53,7 @@ jobs:
           cp ${{github.workspace}}/.github/workflows/dmg_settings.json dmg_settings.json
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           cat $GITHUB_ENV
           echo "==============================="
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run unit tests
         run: xcodebuild test -scheme Radiola CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO


### PR DESCRIPTION
Two commits:
- [dependabot.yml](https://github.blog/news-insights/product-news/keep-all-your-packages-up-to-date-with-dependabot/ "https://github.blog/news-insights/product-news/keep-all-your-packages-up-to-date-with-dependabot/"): Add automated version updates of GitHub Actions dependencies.
- Pin actions to a full length commit SHA


Per GitHub's [security guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions):

> -  Pin actions to a full length commit SHA
>
>    Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

Dependabot [updates comments in GitHub Actions workflows referencing action versions](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/):

> GitHub Actions workflows often specify the version of an action using the commit SHA. Since commit SHAs are immutable, this ensures that Actions always picks the same version. Commit SHAs, however, are not very human friendly, so best practice is to include the semver version in a comment next to the SHA. Dependabot will now update the semver version in comments when updating Actions workflows with a commit SHA version.

Generated via [pinact run](https://formulae.brew.sh/formula/pinact#default).