### PR TITLE
Add favorite star toggle to internet station search rows

### DIFF
--- a/Radiola/AppState.swift
+++ b/Radiola/AppState.swift
@@ -241,11 +241,16 @@ class AppState: ObservableObject {
      *
      * ****************************************/
     func localStation(byURL: String) -> Station? {
-        var res: Station?
-        for sl in localStations {
-            res = sl.firstStation(byURL: byURL)
-            if res != nil {
-                return res
+        return localStationAndList(byURL: byURL)?.station
+    }
+
+    /* ****************************************
+     *
+     * ****************************************/
+    func localStationAndList(byURL: String) -> (station: Station, list: any StationList)? {
+        for list in localStations {
+            if let station = list.firstStation(byURL: byURL) {
+                return (station, list)
             }
         }
 

--- a/Radiola/StationsWindow/InternetStations/InternetStationRows.swift
+++ b/Radiola/StationsWindow/InternetStations/InternetStationRows.swift
@@ -19,12 +19,18 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
     var qualityText = Label()
     var voteText = Label()
     var actionButton = ImageButton()
+    var favoriteButton = ImageButton()
     let menuButton = StationMenuButton()
     let separator = Separator()
 
     private let actionButtonIcons = [
         false: NSImage(systemSymbolName: NSImage.Name("music.house"), accessibilityDescription: "")?.tint(color: .lightGray),
         true: NSImage(systemSymbolName: NSImage.Name("music.house.fill"), accessibilityDescription: "")?.tint(color: .systemYellow),
+    ]
+
+    private let favoriteIcons = [
+        false: NSImage(systemSymbolName: NSImage.Name("star"), accessibilityDescription: "Favorite")?.tint(color: .lightGray),
+        true: NSImage(systemSymbolName: NSImage.Name("star.fill"), accessibilityDescription: "Favorite")?.tint(color: .systemYellow),
     ]
 
     let normalFont = NSFont.systemFont(ofSize: 11)
@@ -41,6 +47,7 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
         super.init(frame: NSRect())
         addSubview(nameEdit)
         addSubview(actionButton)
+        addSubview(favoriteButton)
         addSubview(menuButton)
         addSubview(urlEdit)
         addSubview(separator)
@@ -67,6 +74,10 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
         actionButton.target = self
         actionButton.action = #selector(actionButtonClicked)
 
+        favoriteButton.target = self
+        favoriteButton.action = #selector(favClicked(sender:))
+        favoriteButton.setButtonType(.toggle)
+
         qualityText.attributedStringValue = qualityInfo()
         qualityText.textColor = .secondaryLabelColor
 
@@ -74,6 +85,7 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
         voteText.textColor = .secondaryLabelColor
 
         actionButton.translatesAutoresizingMaskIntoConstraints = false
+        favoriteButton.translatesAutoresizingMaskIntoConstraints = false
         nameEdit.translatesAutoresizingMaskIntoConstraints = false
         urlEdit.translatesAutoresizingMaskIntoConstraints = false
         qualityText.translatesAutoresizingMaskIntoConstraints = false
@@ -82,10 +94,15 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
 
         NSLayoutConstraint.activate([
             actionButton.widthAnchor.constraint(equalToConstant: 16),
+            favoriteButton.widthAnchor.constraint(equalTo: actionButton.widthAnchor),
+            favoriteButton.heightAnchor.constraint(equalTo: actionButton.heightAnchor),
+            favoriteButton.centerYAnchor.constraint(equalTo: actionButton.centerYAnchor),
             nameEdit.leadingAnchor.constraint(equalTo: leadingAnchor),
             nameEdit.trailingAnchor.constraint(equalTo: actionButton.leadingAnchor, constant: -8),
 
-            menuButton.leadingAnchor.constraint(equalTo: actionButton.trailingAnchor, constant: 8),
+            favoriteButton.leadingAnchor.constraint(equalTo: actionButton.trailingAnchor, constant: 8),
+
+            menuButton.leadingAnchor.constraint(equalTo: favoriteButton.trailingAnchor, constant: 8),
             menuButton.trailingAnchor.constraint(equalTo: trailingAnchor),
             menuButton.widthAnchor.constraint(equalTo: actionButton.widthAnchor),
             menuButton.heightAnchor.constraint(equalTo: actionButton.heightAnchor),
@@ -107,7 +124,7 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
 
         separator.alignBottom(of: self)
 
-        refreshActionButton()
+        refreshButtons()
     }
 
     /* ****************************************
@@ -121,15 +138,27 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
      *
      * ****************************************/
     @objc private func actionButtonClicked(sender: NSButton) {
-        guard let list = AppState.shared.localStations.first else { return }
-        let inLocal = list.firstStation(byURL: station.url) != nil
-
-        if !inLocal {
-            let s = list.createStation(title: station.title, url: station.url)
-            list.append(s)
+        if AppState.shared.localStation(byURL: station.url) == nil,
+           let (_, list) = createLocalStation() {
             list.trySave()
-            refreshActionButton()
         }
+
+        refreshButtons()
+    }
+
+    /* ****************************************
+     *
+     * ****************************************/
+    @objc private func favClicked(sender: NSButton) {
+        if let (localStation, list) = AppState.shared.localStationAndList(byURL: station.url) {
+            localStation.isFavorite = !localStation.isFavorite
+            list.trySave()
+        } else if let (localStation, list) = createLocalStation() {
+            localStation.isFavorite = true
+            list.trySave()
+        }
+
+        refreshButtons()
     }
 
     /* ****************************************
@@ -139,6 +168,39 @@ class InternetStationRow: NSView, NSTextFieldDelegate {
         let inLocal = AppState.shared.localStation(byURL: station.url) != nil
         actionButton.image = actionButtonIcons[inLocal]!
         actionButton.toolTip = inLocal ? "" : NSLocalizedString("Add the station to my stations list", comment: "Button tooltip")
+    }
+
+    /* ****************************************
+     *
+     * ****************************************/
+    private func refreshFavoriteButton() {
+        let isFavorite = AppState.shared.localStation(byURL: station.url)?.isFavorite ?? false
+
+        favoriteButton.image = favoriteIcons[isFavorite]!
+        favoriteButton.state = isFavorite ? .on : .off
+        favoriteButton.toolTip = isFavorite ?
+            NSLocalizedString("Unmark station as favorite", comment: "Station favorite star icon tooltip") :
+            NSLocalizedString("Mark station as favorite", comment: "Station favorite star icon tooltip")
+    }
+
+    /* ****************************************
+     *
+     * ****************************************/
+    private func refreshButtons() {
+        refreshActionButton()
+        refreshFavoriteButton()
+    }
+
+    /* ****************************************
+     *
+     * ****************************************/
+    private func createLocalStation() -> (station: Station, list: any StationList)? {
+        guard let list = AppState.shared.localStations.first else { return nil }
+
+        let localStation = list.createStation(title: station.title, url: station.url)
+        list.append(localStation)
+
+        return (localStation, list)
     }
 
     /* ****************************************


### PR DESCRIPTION
## Summary

Adds a star button to each internet-radio search row so you can favorite a station in one click, right from the search results. Clicking the star marks the station as a favorite, and if it is not yet in My Stations it is added and favorited at the same time. Clicking the star again only clears the favorite flag; the station stays in My Stations.

## Why this matters

Today favoriting a station found via internet search takes several steps: play it, search again, add it to My Stations with the home icon, then open My Stations and star it. Issue #124 asks for a one-step way to favorite directly from the search results. The maintainer agreed to add a star icon, and the reporter confirmed that un-starring should only clear the favorite flag, not remove the station.

## Changes

- `InternetStationRows.swift`: new star `favoriteButton` next to the existing home button, mirroring the filled/outline star and tooltips from `LocalStationRows`. The star resolves the backing local station via `AppState.localStationAndList(byURL:)`, toggles `isFavorite` when present, or creates the local station and sets the favorite flag when absent. Both buttons refresh after each click.
- `AppState.swift`: added `localStationAndList(byURL:)` returning the matching local station together with its owning list so the row can save the change; `localStation(byURL:)` now delegates to it with no behavior change.

## Testing

- `xcodebuild build -project Radiola.xcodeproj -scheme Radiola -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` succeeds.
- `xcodebuild test` with signing disabled: all 3 existing tests pass.
- Rows are not unit-tested; behavior was reasoned through against the existing `LocalStationRows` favorite pattern and the shared `createStation`/`append`/`trySave` path.

Fixes #124

AI was used for assistance.
